### PR TITLE
Fixed broken mongo java driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN cd /tmp && \
 RUN cd ${CATALINA_HOME}/lib && \
     curl -O https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_DRIVER_VERSION}/mysql-connector-java-${MYSQL_DRIVER_VERSION}.jar && \
     curl -O https://jdbc.postgresql.org/download/postgresql-${POSTGRES_DRIVER_VERSION}.jar && \
-    curl -O https://oss.sonatype.org/content/repositories/releases/org/mongodb/mongo-java-driver/${MONGODB_DRIVER_VERSION}/mongo-java-driver-${MONGODB_DRIVER_VERSION}.jar && \
+    curl -L -O https://oss.sonatype.org/content/repositories/releases/org/mongodb/mongo-java-driver/${MONGODB_DRIVER_VERSION}/mongo-java-driver-${MONGODB_DRIVER_VERSION}.jar && \
     curl -O https://downloads.mariadb.com/Connectors/java/connector-java-${MARIADB_DRIVER_VERSION}/mariadb-java-client-${MARIADB_DRIVER_VERSION}.jar
 
 # Update server.xml to set pwm webapp to root


### PR DESCRIPTION
PWM failed to start with these logs:

```
pwm_1   | 2019-06-09T02:08:11Z, TRACE, pwm.PwmAboutProperty, error generating about value for 'app_localDbStorageSize', error: null
pwm_1   | 2019-06-09T02:08:11Z, TRACE, pwm.PwmAboutProperty, error generating about value for 'app_localDbFreeSpace', error: null
pwm_1   | 09-Jun-2019 02:08:11.919 WARNING [localhost-startStop-1] org.apache.tomcat.util.scan.StandardJarScanner.processURLs Failed to scan [file:/usr/local/tomcat/lib/mongo-java-driver-3.9.1.jar] from classloader hierarchy
pwm_1   | 	java.util.zip.ZipException: error in opening zip file
pwm_1   | 		at java.util.zip.ZipFile.open(Native Method)
pwm_1   | 		at java.util.zip.ZipFile.<init>(ZipFile.java:225)
pwm_1   | 		at java.util.zip.ZipFile.<init>(ZipFile.java:155)
pwm_1   | 		at java.util.jar.JarFile.<init>(JarFile.java:166)
pwm_1   | 		at java.util.jar.JarFile.<init>(JarFile.java:130)
pwm_1   | 		at org.apache.tomcat.util.compat.JreCompat.jarFileNewInstance(JreCompat.java:196)
pwm_1   | 		at org.apache.tomcat.util.scan.JarFileUrlJar.<init>(JarFileUrlJar.java:65)
pwm_1   | 		at org.apache.tomcat.util.scan.JarFactory.newInstance(JarFactory.java:49)
pwm_1   | 		at org.apache.tomcat.util.scan.StandardJarScanner.process(StandardJarScanner.java:374)
pwm_1   | 		at org.apache.tomcat.util.scan.StandardJarScanner.processURLs(StandardJarScanner.java:309)
pwm_1   | 		at org.apache.tomcat.util.scan.StandardJarScanner.doScanClassPath(StandardJarScanner.java:266)
pwm_1   | 		at org.apache.tomcat.util.scan.StandardJarScanner.scan(StandardJarScanner.java:229)
pwm_1   | 		at org.apache.jasper.servlet.TldScanner.scanJars(TldScanner.java:262)
pwm_1   | 		at org.apache.jasper.servlet.TldScanner.scan(TldScanner.java:104)
pwm_1   | 		at org.apache.jasper.servlet.JasperInitializer.onStartup(JasperInitializer.java:101)
pwm_1   | 		at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5225)
pwm_1   | 		at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
pwm_1   | 		at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:754)
pwm_1   | 		at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:730)
pwm_1   | 		at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:744)
pwm_1   | 		at org.apache.catalina.startup.HostConfig.deployDirectory(HostConfig.java:1135)
pwm_1   | 		at org.apache.catalina.startup.HostConfig$DeployDirectory.run(HostConfig.java:1869)
pwm_1   | 		at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
pwm_1   | 		at java.util.concurrent.FutureTask.run(FutureTask.java:266)
pwm_1   | 		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
pwm_1   | 		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
pwm_1   | 		at java.lang.Thread.run(Thread.java:748)
pwm_1   | 09-Jun-2019 02:08:11.926 INFO [localhost-startStop-1] org.apache.jasper.servlet.TldScanner.scanJars At least one JAR was scanned for TLDs yet contained no TLDs. Enable debug logging for this logger for a complete list of JARs that were scanned but no TLDs were found in them. Skipping unneeded JARs during scanning can improve startup time and JSP compilation time.
pwm_1   | 09-Jun-2019 02:08:12.049 INFO [localhost-startStop-1] org.apache.catalina.startup.HostConfig.deployDirectory Deployment of web application directory [/usr/local/tomcat/webapps/examples] has finished in [1,136] ms
```

Seems the mongo java driver can't open by java.util.zip.ZipFile, so I try to find out what's going on with the mongo-java-driver:

```
$ docker exec -it ldap_pwm_1 ls -al  /usr/local/tomcat/lib/mongo-java-driver-3.9.1.jar
-rw-r--r-- 1 pwm pwm 126 Jun  8 16:56 /usr/local/tomcat/lib/mongo-java-driver-3.9.1.jar
```

I found that the mongo-java-driver-3.9.1.jar only have 126 Bytes, seems that's not a correct jar file.

I tried download mongo-java-driver-3.9.1.jar by the same command just like Dockerfile execute:

```
$ docker exec -it ldap_pwm_1 curl -O https://oss.sonatype.org/content/repositories/releases/org/mongodb/mongo-java-driver/3.9.1/mongo-java-driver-3.9.1.jar
```

And it really got 126 Bytes mongo-java-driver-3.9.1.jar!

Then I tried download mongo-java-driver-3.9.1.jar in my browser, and it got 2MB size, and found that the url be redirected to https://repo1.maven.org/maven2/org/mongodb . So, that's it!

Curl won't follow redirects by default!

Finally, append the "-L" argument to curl program force it support redirects and the driver download correctly.

